### PR TITLE
Support prefix

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -50,7 +50,7 @@ class Redis
         if (!extension_loaded('redis')) {
             throw new \RuntimeException('Please make sure the PHP Redis extension is installed and enabled.');
         }
-        
+
         $redis = new RedisConnection();
         $address = $config['host'];
         $config = [
@@ -60,6 +60,7 @@ class Redis
             'auth' => $config['options']['auth'] ?? '',
             'timeout' => $config['options']['timeout'] ?? 2,
             'ping' => $config['options']['ping'] ?? 55,
+            'prefix' => $config['options']['prefix'] ?? '',
         ];
         $redis->connectWithConfig($config);
         return $redis;

--- a/src/RedisConnection.php
+++ b/src/RedisConnection.php
@@ -19,7 +19,7 @@ use Workerman\Worker;
 class RedisConnection extends \Redis
 {
     /**
-     * @var array 
+     * @var array
      */
     protected $config = [];
 
@@ -41,6 +41,9 @@ class RedisConnection extends \Redis
         }
         if (!empty($this->config['db'])) {
             $this->select($this->config['db']);
+        }
+        if (!empty($this->config['prefix'])) {
+            $this->setOption(\Redis::OPT_PREFIX, $this->config['prefix']);
         }
         if (Worker::getAllWorkers() && !$timer) {
             $timer = Timer::add($this->config['ping'] ?? 55, function ()  {

--- a/src/config/plugin/webman/redis-queue/redis.php
+++ b/src/config/plugin/webman/redis-queue/redis.php
@@ -5,6 +5,7 @@ return [
         'options' => [
             'auth' => null,       // 密码，字符串类型，可选参数
             'db' => 0,            // 数据库
+            'prefix' => '',       // key 前缀
             'max_attempts'  => 5, // 消费失败后，重试次数
             'retry_seconds' => 5, // 重试间隔，单位秒
         ]


### PR DESCRIPTION
cache/session/redis 等使用都支持了prefix，但redis-queue不支持，修改提供支持

异步 Client 的支持需要修改 `workerman/redis-queue` 使其支持