### PR TITLE
ADD: unix socket connection support

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -91,7 +91,7 @@ class Redis
         $redis = new RedisConnection();
         $address = $config['host'];
         $config = [
-            'host' => parse_url($address, PHP_URL_HOST),
+            'host' => str_starts_with($address, 'unix:///') ? $address : parse_url($address, PHP_URL_HOST),
             'port' => parse_url($address, PHP_URL_PORT),
             'db' => $config['options']['database'] ?? $config['options']['db'] ?? 0,
             'auth' => $config['options']['auth'] ?? '',


### PR DESCRIPTION
The upstream phpredis extension supports connecting to Redis using Unix sockets. However, the current connection method in this project uses `parse_url($address, PHP_URL_HOST)`, which inadvertently filters out Unix socket paths.
This pull request introduces a check using `str_starts_with($address, 'unix:///')` before the `parse_url` call. If the address starts with `unix:///`, it is directly passed to the subsequent connection logic, preserving the functionality for Unix socket connections. Otherwise, the existing parsing mechanism remains unchanged.
Are there any alternative or more robust approaches you would recommend for supporting Unix socket connections? I'm open to any suggestions you might have.